### PR TITLE
✅ Share API Trouble

### DIFF
--- a/src/components/LinkBox.svelte
+++ b/src/components/LinkBox.svelte
@@ -4,10 +4,9 @@
   import SingleShareBtn from "./BtnSingleShare.svelte";
 
   export let value;
-  let sharing = false;
 
-  const handleInputClick = async () => {
-    await navigator.clipboard.writeText(value);
+  const copyToClipboard = async textValue => {
+    await navigator.clipboard.writeText(textValue);
 
     $appStore.messages = addMessage(
       $appStore.messages,
@@ -18,28 +17,8 @@
     );
   };
 
-  const handleSingleShareBtnClick = async () => {
-    sharing = true;
-    setTimeout(() => {
-      sharing = false;
-    }, 1000);
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: $eventDataStore.name,
-          text: $eventDataStore.description,
-          url: value
-        });
-      } catch (err) {
-        console.log(err);
-        $appStore.messages = addMessage(
-          $appStore.messages,
-          "error",
-          "shareLinkShareAPI",
-          "Something went wrong :("
-        );
-      }
-    }
+  const handleInputClick = async () => {
+    await copyToClipboard(value);
   };
 </script>
 
@@ -77,12 +56,12 @@
     readonly
     bind:value
     on:click={handleInputClick} />
-  {#if navigator.share && !sharing}
-    <SingleShareBtn
-      width={25}
-      height={25}
-      marginTop={-2}
-      marginLeft={-2}
-      on:singlesharebtnclick|once={handleSingleShareBtnClick} />
-  {/if}
+
+  <SingleShareBtn
+    width={25}
+    height={25}
+    marginTop={-2}
+    marginLeft={-2}
+    {value} />
+
 </div>

--- a/src/components/LinkBox.svelte
+++ b/src/components/LinkBox.svelte
@@ -4,6 +4,7 @@
   import SingleShareBtn from "./BtnSingleShare.svelte";
 
   export let value;
+  let sharing = false;
 
   const handleInputClick = async () => {
     await navigator.clipboard.writeText(value);
@@ -17,24 +18,26 @@
     );
   };
 
-  const handleSingleShareBtnClick = () => {
+  const handleSingleShareBtnClick = async () => {
+    sharing = true;
     if (navigator.share) {
-      navigator
-        .share({
+      try {
+        await navigator.share({
           title: $eventDataStore.name,
           text: $eventDataStore.description,
           url: value
-        })
-        .then()
-        .catch(
-          err =>
-            ($appStore.messages = addMessage(
-              $appStore.messages,
-              "error",
-              "shareLinkShareAPI",
-              "Something went wrong sorry :("
-            ))
+        });
+        sharing = false;
+      } catch (err) {
+        console.log(err);
+        $appStore.messages = addMessage(
+          $appStore.messages,
+          "error",
+          "shareLinkShareAPI",
+          "Something went wrong :("
         );
+        sharing = false;
+      }
     }
   };
 </script>
@@ -73,7 +76,7 @@
     readonly
     bind:value
     on:click={handleInputClick} />
-  {#if navigator.share}
+  {#if navigator.share && !sharing}
     <SingleShareBtn
       width={25}
       height={25}

--- a/src/components/LinkBox.svelte
+++ b/src/components/LinkBox.svelte
@@ -83,6 +83,6 @@
       height={25}
       marginTop={-2}
       marginLeft={-2}
-      on:singlesharebtnclick={handleSingleShareBtnClick} />
+      on:singlesharebtnclick|once={handleSingleShareBtnClick} />
   {/if}
 </div>

--- a/src/components/LinkBox.svelte
+++ b/src/components/LinkBox.svelte
@@ -20,6 +20,9 @@
 
   const handleSingleShareBtnClick = async () => {
     sharing = true;
+    setTimeout(() => {
+      sharing = false;
+    }, 1000);
     if (navigator.share) {
       try {
         await navigator.share({
@@ -27,7 +30,6 @@
           text: $eventDataStore.description,
           url: value
         });
-        sharing = false;
       } catch (err) {
         console.log(err);
         $appStore.messages = addMessage(
@@ -36,7 +38,6 @@
           "shareLinkShareAPI",
           "Something went wrong :("
         );
-        sharing = false;
       }
     }
   };

--- a/src/components/LinkBoxEdit.svelte
+++ b/src/components/LinkBoxEdit.svelte
@@ -1,5 +1,6 @@
 <script>
   import EditIcon from "../components/Icons/Edit.svelte";
+  import SingleShareBtn from "../components/BtnSingleShare.svelte";
 
   export let value;
 </script>
@@ -41,4 +42,5 @@
     name="linkBoxEdit"
     readonly
     bind:value />
+  <SingleShareBtn width={25} height={25} marginLeft={-2} {value} />
 </div>

--- a/src/components/LinkBoxGlobal.svelte
+++ b/src/components/LinkBoxGlobal.svelte
@@ -1,5 +1,6 @@
 <script>
   import GlobeIcon from "../components/Icons/Globe.svelte";
+  import SingleShareBtn from "../components/BtnSingleShare.svelte";
 
   export let value;
 </script>
@@ -41,4 +42,6 @@
     name="linkBoxGlobal"
     readonly
     bind:value />
+
+  <SingleShareBtn width={25} height={25} marginLeft={-2} {value} />
 </div>


### PR DESCRIPTION
On iOS the share dialog will only open once, on the second try it throws an error:

![image](https://user-images.githubusercontent.com/41547570/95192806-03e89480-07d3-11eb-95ba-19e56285684b.png)

[Related Stack Overflow question](https://stackoverflow.com/questions/64055853/navigator-share-only-working-once-in-ios-second-click-throws-error-request-is)

So I will wait an see if something happens in the next months, because this seems to be a problem for every implementation I found on the web.

For now the first share will work and then the button is used for the copy to clipboard action.